### PR TITLE
Removed gh action is in beta from readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Example of monorepo module structure:
 
 ## Installation
 
-To use this GitHub Action, you must have access to [GitHub Actions](https://github.com/features/actions). GitHub Actions are currently only available in private beta (you must [apply for access](https://github.com/features/actions)) and only work in private repos.
-
 To setup this action:
 
 1. Create a `.github/worksflows/main.yml` in your GitHub repo ([more info](https://help.github.com/en/articles/configuring-a-workflow)).


### PR DESCRIPTION
Inside Readme.md in [Installation section](https://github.com/adamzolyak/monorepo-pr-labeler-action#installation) there is a note written which summaries as

>	...GitHub Actions are currently only available in private beta...

The above statement does not make sense now since gh action feature is live & available to all irrespective of the fact that repo is public or private﻿
