### PR TITLE
[ENHANCE]:Added support for prefix & suffix using with

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_DIRS: 'directory1|directory2'
+        with:
+          prefix: 'sample_prefix' # optional
+          suffix: 'sample_suffix' # optional
 ```
 
-Optionally add a `BASE_DIRS` variable under `env` if modules are located within a base directory(ies). You can configure one (ex. `directory1`) or more directories (ex. `directory1|directory2|...`).
+### Options
+ - Add a `BASE_DIRS` variable under `env` if modules are located within a base directory(ies). You can configure one (ex. `directory1`) or more directories (ex. `directory1|directory2|...`).
+ - Add `prefix` or `suffix` under `with` if you wish to add prefix or suffix the repo name in the label respectively.
 
 3. Whenever you open, edit, close, etc a pull request, the action will run!
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,12 @@
 name: "Monorepo PR Repo Labeler"
 description: "Monorepo PR Repo Labeler"
+inputs:
+  prefix:
+    description: Prefix to repo name to be used in label
+    required: false
+  suffix:
+    description: Suffix to repo name to be used in label
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/app.js
+++ b/app.js
@@ -50,7 +50,7 @@ async function prMonorepoRepoLabeler() {
     if (repo) {
       console.log(`labeling repo: ${repo}`)
 
-      const repoLabel = `📁 Repo: ${repo}`
+      const repoLabel = helpers.getLabel(repo);
 
       helpers.addLabel(
         octokit,

--- a/helpers.js
+++ b/helpers.js
@@ -74,3 +74,11 @@ module.exports.addLabel = function(
       console.log(err)
     })
 }
+
+module.exports.getLabel = function(repo) {
+  const prefix = process.env.INPUT_PREFIX || '';
+  const suffix = process.env.INPUT_SUFFIX || '';
+  repo = repo || '';
+
+  return `${prefix} ${repo} ${suffix}`.trim();
+}

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -12,6 +12,7 @@ describe('prMonorepoRepoLabeler', () => {
     let eventData, fileData
     helpers.readFilePromise = jest.fn(() => eventData)
     helpers.listFiles = jest.fn(() => fileData)
+    helpers.getLabel = jest.fn((repo) => repo);
     helpers.getMonorepo = jest.fn()
     helpers.addLabel = jest.fn()
     eventData = `{
@@ -51,6 +52,7 @@ describe('prMonorepoRepoLabeler', () => {
     let eventData, fileData
     helpers.readFilePromise = jest.fn(() => eventData)
     helpers.listFiles = jest.fn(() => fileData)
+    helpers.getLabel = jest.fn((repo) => repo);
     helpers.getMonorepo = jest.fn()
     helpers.addLabel = jest.fn()
     eventData = `{

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -86,3 +86,45 @@ describe('addLabel', () => {
     ])
   })
 })
+
+describe('getLabel', () => {
+  afterEach(() => {
+    delete process.env.INPUT_PREFIX;
+    delete process.env.INPUT_SUFFIX;
+  });
+
+  it('Returns label with prefix & suffic attached to repo name', () => {
+    process.env.INPUT_PREFIX = 'sample_prefix';
+    process.env.INPUT_SUFFIX = 'sample_suffix';
+
+    const repoName = 'sample_repo';
+
+    expect(helpers.getLabel(repoName)).
+      toBe('sample_prefix sample_repo sample_suffix');
+  });
+
+  it('Returns label only with suffix when only suffix passed as input', () => {
+    process.env.INPUT_SUFFIX = 'sample_suffix';
+    const repoName = 'sample_repo';
+
+    expect(helpers.getLabel(repoName))
+      .toBe('sample_repo sample_suffix');
+  });
+
+  it('Returns label only with prefix when only prefix passed as input', () => {
+    process.env.INPUT_SUFFIX = 'sample_prefix';
+    const repoName = 'sample_repo';
+
+    expect(helpers.getLabel(repoName))
+      .toBe('sample_repo sample_prefix');
+  });
+
+  it('Returns only repo name when no prefix & suffix', () => {
+    expect(helpers.getLabel('sample_repo'))
+      .toBe('sample_repo');
+  });
+
+  it('returns empty string without input & without argument', () => {
+    expect(helpers.getLabel()).toBe('');
+  });
+});


### PR DESCRIPTION
Fix: https://github.com/adamzolyak/monorepo-pr-labeler-action/issues/14
﻿	- User can specify the prefix & suffix explicitly to the PR using with param in workflow.yaml
	- Wrote an extra helper to extract the values from environment & create the label for PR
	- Modified the existing test to mock newly added helper
