### PR TITLE
[CI][GH-ACTION]: Migration to gh-action as CI tool

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,23 @@
+name: Validate
+on: [push]
+
+jobs:
+  validate-code:
+    name: Test GH action with unit testing
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          check-latest: true
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Unit tests
+        run: npm test -- --ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-slim
+FROM node:14
 
 LABEL "com.github.actions.name"="Monorepo PR Repo Labeler"
 LABEL "com.github.actions.description"="Label PRs with the repo(s) that they impact for monorepos"


### PR DESCRIPTION
Fixes: https://github.com/adamzolyak/monorepo-pr-labeler-action/issues/18
	- Wrote a validate.yaml as workflow for running unit tests
	- Ugraded to NodeJS v14 in Dockerfile
	- Introduced eslint in the code for linting the source code